### PR TITLE
Clean requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 gql[requests]==3.4.0
-aiohttp==3.8.3
-gql==3.4.0
+requests=2.29.0
 pandas==1.5.3
 pika==1.3.1
 nltk==3.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gql==3.4.0
 pandas==1.5.3
 pika==1.3.1
 nltk==3.8.1
+python-iso639==2023.4.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gql[requests]==3.4.0
-requests=2.29.0
+requests==2.29.0
 pandas==1.5.3
 pika==1.3.1
 nltk==3.8.1


### PR DESCRIPTION
- Add missing dependency python-iso639 (used to convert language codes)
- Remove gql (gql[requests] is already a variant of gql with support for requests)
- Remove aiohttp (not used)
- Add requests 2.29.0 (last compatible version with urllib 2.x) #7 